### PR TITLE
make sure res is bound correctly in handleError

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ function Conformity () {
 
 Conformity.prototype.handleFailure = function (req, res, next) {
     return function (status, callback) {
-        var send = res.send;
+        var send = res.send.bind(res);
         if (res.prettyError) {
             send = res.prettyError;
         }


### PR DESCRIPTION
See https://stackoverflow.com/a/42832428/8652414 - I was running into a weird issue where an invalid request was clobbering the `this` in a `this.req` in the funciton body of the `res.send = function send(body) {` part of the Express library, and this turned out to be the cause